### PR TITLE
devops: run gh actions only on PRs to master

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,7 @@ name: Rust
 on:
   push: { branches: [master] }
   pull_request:
-    branches: [ "*" ]
+    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Frontend PRs are wasting actions minutes :eyes: 